### PR TITLE
Disable doclint checks when using Java 8's javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,9 +168,6 @@
             <goals>
               <goal>jar</goal>
             </goals>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -320,4 +317,24 @@
     </plugins>
   </reporting>
 
+  <profiles>
+    <profile>
+      <id>docline-java8-disable</id>
+      <activation>
+        <jdk>[1.8,</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Java 8's javadoc introduces new checks, which make the JSI build fail.

These should obviously be fixed at one point, but for making it at least possible to build this PR disables the doclint feature.

The profile becomes active when JDK 1.8+ is used, I tested building using JDK 1.7.0_45 and JDK 1.8.0-b129.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8:jar (attach-javadocs) on project jsi: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/BuildProperties.java:52: warning: no @return
[ERROR] public static String getVersion() {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/BuildProperties.java:60: warning: no @return
[ERROR] public static String getScmRevisionId() {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/Point.java:44: warning: no @param for other
[ERROR] public void set(Point other) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/PriorityQueue.java:47: error: malformed HTML
[ERROR] * 00 < 01, 00 < 02, 02 < 05, 02 < 06
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/PriorityQueue.java:47: error: malformed HTML
[ERROR] * 00 < 01, 00 < 02, 02 < 05, 02 < 06
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/PriorityQueue.java:47: error: malformed HTML
[ERROR] * 00 < 01, 00 < 02, 02 < 05, 02 < 06
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/PriorityQueue.java:47: error: malformed HTML
[ERROR] * 00 < 01, 00 < 02, 02 < 05, 02 < 06
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/Rectangle.java:71: warning: no @param for r
[ERROR] public void set(Rectangle r) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/Rectangle.java:91: warning: no @param for r
[ERROR] public boolean edgeOverlaps(Rectangle r) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/Rectangle.java:91: warning: no @return
[ERROR] public boolean edgeOverlaps(Rectangle r) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/Rectangle.java:374: warning: no @return
[ERROR] public Rectangle union(Rectangle r) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/Rectangle.java:417: warning: no @return
[ERROR] public boolean sameObject(Object o) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/Rectangle.java:436: warning: no @return
[ERROR] public float width() {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/SpatialIndex.java:119: warning: no @param for p
[ERROR] public void nearestNUnsorted(Point p, TIntProcedure v, int n, float distance);
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/SpatialIndex.java:119: warning: no @param for v
[ERROR] public void nearestNUnsorted(Point p, TIntProcedure v, int n, float distance);
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/SpatialIndex.java:119: warning: no @param for n
[ERROR] public void nearestNUnsorted(Point p, TIntProcedure v, int n, float distance);
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/SpatialIndex.java:119: warning: no @param for distance
[ERROR] public void nearestNUnsorted(Point p, TIntProcedure v, int n, float distance);
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/SpatialIndex.java:146: warning: no @return
[ERROR] public int size();
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/SpatialIndex.java:153: warning: no @return
[ERROR] public Rectangle getBounds();
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/SpatialIndex.java:160: warning: no @return
[ERROR] public String getVersion();
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:120: error: text not allowed in <ul> element
[ERROR] * <li>MaxNodeEntries</li> This specifies the maximum number of entries
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:123: error: text not allowed in <ul> element
[ERROR] * <li>MinNodeEntries</li> This specifies the minimum number of entries
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:126: error: unexpected end tag: </p>
[ERROR] * </ul></p>
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:564: warning: no @param for id
[ERROR] public Node getNode(int id) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:564: warning: no @return
[ERROR] public Node getNode(int id) {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:571: warning: no @return
[ERROR] public int getHighestUsedNodeId() {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:578: warning: no @return
[ERROR] public int getRootNodeId() {
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/RTree.java:49: error: unexpected end tag: </p>
[ERROR] * </ul></p>
[ERROR] ^
[ERROR] /home/andreas/project/jsi/src/main/java/com/infomatiq/jsi/rtree/SortedList.java:113: warning: no @return
[ERROR] public float getLowestPriority() {
[ERROR] ^
[ERROR] 
[ERROR] Command line was: /usr/java/jdk1.8.0-b129/jre/../bin/javadoc @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/home/andreas/project/jsi/target/apidocs' dir.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
