### PR TITLE
Update pom.xml to remove http protocol that breaks maven 6.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
 
   <name>jsi</name>
   <description>Java Spatial Index library</description>
-  <url>http://www.sourceforge.net/projects/jsi</url>
+  <url>https://www.sourceforge.net/projects/jsi</url>
 
   <licenses>
     <license>
       <name>The GNU Lesser General Public License, Version 2.1 or later</name>
-        <url>http://www.gnu.org/licenses/lgpl-2.1.txt</url>
+        <url>https://www.gnu.org/licenses/lgpl-2.1.txt</url>
     </license>
   </licenses>
 
@@ -22,7 +22,7 @@
     <developer>
       <name>Aled Morris</name>
       <email>aled@users.sourceforge.net</email>
-      <url>http://github.com/aled/jsi</url>
+      <url>https://github.com/aled/jsi</url>
     </developer>
   </developers>
 


### PR DESCRIPTION
see https://maven.apache.org/docs/3.8.1/release-notes.html

"The decision was made to block such external HTTP repositories by default"

Not 100% sure which http references in the pom.xml file need to be changed to https, I imagine the project URL as a minimum, however there seems no reason to keep any of the references as https is available for sourceforge.net, gnu.org and github.com.